### PR TITLE
Router component rewrite

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,6 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+2019-06-16: A bug in the Router component was found, and a clean rewrite was the better option because the original code was too convoluted to improve upon. No changes in usage of the component.
 2019-06-12: First assembly of the cleaned source code for Github submission
 

--- a/src/core_components/FileWriter.h
+++ b/src/core_components/FileWriter.h
@@ -40,6 +40,7 @@ class FileWriterHolder {
     std::string mFstPrefix;
     std::string mJsonOutputFormat;
     std::string mFeaturesNpz;
+    Matrix mFeaturesAccum;
 };
 
 

--- a/src/core_components/Router.h
+++ b/src/core_components/Router.h
@@ -28,10 +28,11 @@ class RouterComponent : public LoopProcessor {
 
     int64_t mToRouteStreamOffset;
     std::vector<int64_t> mRoutedStreamOffsets;
+    std::vector<uint64_t> mAccumRouteIdx;
+    int mCurrentRouteIdx;
 
     // SAD Nbest router
     std::vector<DecoderMessage_ptr> mAccumToRouteBaseMsg;
-    std::vector<uint64_t> mAccumTop1;
     std::vector<uint64_t> mAccumAlignment;
     std::vector<bool> mAccumEndOfUtt;
     std::vector<std::string> mAccumUttId;

--- a/test/python.test
+++ b/test/python.test
@@ -9,10 +9,12 @@ then
 fi
 
 
+PYTHON=$PYTHON_HOME/bin/python3
 if [ "$(expr substr $(uname -s) 1 9)" == "CYGWIN_NT" ]; then
   PYTHON_HOME_CYGWIN=$(cygpath -m $PYTHON_HOME)
-  OVERRIDE="-x python.python_executable=$PYTHON_HOME_CYGWIN/python.exe"
+  PYTHON=$PYTHON_HOME_CYGWIN/python.exe 
+  OVERRIDE="-x python.python_executable=$PYTHON"
 fi
 
 godec $OVERRIDE python_test.json
-$PYTHON_HOME/bin/python3 python_test_compare_matrix.py
+$PYTHON python_test_compare_matrix.py

--- a/test/python_test_compare_matrix.py
+++ b/test/python_test_compare_matrix.py
@@ -22,6 +22,7 @@ for uttId in orig_feats.files:
 
 godec_norm_feats = np.load("python_test_norm_feats.npz")
 accum_orig_feats = None
+highestMaxDiff = 0.0
 for uttId in orig_feats.files:
   if (accum_orig_feats is None):
     accum_orig_feats = orig_feats[uttId]
@@ -32,7 +33,11 @@ for uttId in orig_feats.files:
     std = np.std(accum_orig_feats[rowIdx]-mean,ddof=1)
     norm_orig = (orig_feats[uttId][rowIdx]-mean)/std
     maxDiff = np.max(np.abs(np.subtract(norm_orig,godec_norm_feats[uttId][rowIdx])))
+    highestMaxDiff = max(highestMaxDiff, maxDiff)
     if (maxDiff > 1E-06):
       sys.stderr.write("Different matrices for utt "+uttId+"\n")
       sys.stderr.flush()
       exit(-1)
+
+print("maxDiff= "+str(highestMaxDiff))
+

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -1,8 +1,6 @@
 #!/bin/bash -v
 set -e
 
-windows_skipped_tests="python.test"
-
 if [ "$#" -ne 1 ]; then
     echo "Usage: run_tests.sh <installation directory>"
     exit -1
@@ -10,11 +8,23 @@ fi
 
 . $1/env.sh
 
+
+# Set to a semicolon-separated list of tests to be skipped
+skipped_tests=""
+# Set to test in order to run just that one
+only_test=""
+
+if [ "$(expr substr $(uname -s) 1 9)" == "CYGWIN_NT" ]; then
+    skipped_tests="$skipped_tests;"
+fi
+
 for reg_test in *.test; do
-    if [ "$(expr substr $(uname -s) 1 9)" == "CYGWIN_NT" ]; then
-      if [[ $windows_skipped_tests == *"$reg_test"* ]]; then
-        continue;
-      fi
+    if [ ! -z $only_test ] && [ $only_test != "$reg_test" ]; then
+      continue;
+    fi
+
+    if [[ $skipped_tests == *"$reg_test"* ]]; then
+      continue;
     fi
     echo "############################ Starting $reg_test ##########################"
     time ./$reg_test


### PR DESCRIPTION
This addresses issue #2, the issue of the Router having a bug when spreading end-of-convo over the different streams. A new regression test was added for the Router component.
Also, a minor fix to the FileWriter. In NPZ writing mode it needed to buffer the features because the cnpy library will actually not append to an existing key, but rather just create a second entry.