### PR TITLE
Fix decay factor in AccumCovariance class

### DIFF
--- a/src/core_components/AccumCovariance.cc
+++ b/src/core_components/AccumCovariance.cc
@@ -52,7 +52,10 @@ void AccumCovariance::addData(const Matrix& newData) {
     if (mDecayRate != 1.0f) {
         double cumDecayRate = exp(log(mDecayRate)*newDataN);
         accumN *= cumDecayRate; // Simply pretend we have less history
+        accumMean *= cumDecayRate;
+        accumCovar *= cumDecayRate;
     }
+
     covarIsCurrent = false;
     invCovarIsCurrent = false;
 }


### PR DESCRIPTION
There was a bug in the AccumCovariance class when setting the decay factor to anything but -1. We didn't decay the two accum variables, which caused a drift in the resulting output features.