### PR TITLE
AccumCovar was not checking for a degenerate covariance matrix

### DIFF
--- a/src/core_components/AccumCovariance.cc
+++ b/src/core_components/AccumCovariance.cc
@@ -82,7 +82,11 @@ Matrix AccumCovariance::getInvCovariance(bool biased) {
     if (invCovarIsCurrent && currentInvCovarBias == biased) return currentInvCovar;
     if (mType == Diagonal) {
         currentInvCovar = getCovariance(biased);
-        currentInvCovar.diagonal() = currentInvCovar.diagonal().array().inverse();
+        if (currentInvCovar.diagonal().array().abs().minCoeff() > std::numeric_limits<double>::epsilon()) {
+            currentInvCovar.diagonal() = currentInvCovar.diagonal().array().inverse();
+        } else {
+            currentInvCovar = Matrix::Identity(currentInvCovar.rows(), currentInvCovar.cols());
+        }
     } else {
         currentInvCovar = pinv(getCovariance(biased));
     }

--- a/src/core_components/AccumCovariance.h
+++ b/src/core_components/AccumCovariance.h
@@ -1,12 +1,16 @@
 #pragma once
 
 #include <godec/HelperFuncs.h>
+#include <iostream>
 
 namespace Godec {
 
 template<typename MatrixType>
 MatrixType pinv(const MatrixType &a, double epsilon = std::numeric_limits<double>::epsilon()) {
     Eigen::JacobiSVD<MatrixType> svd(a, Eigen::ComputeThinU | Eigen::ComputeThinV);
+    if (svd.nonzeroSingularValues() == 0) {
+        return Matrix::Identity(a.rows(), a.cols());
+    }
     double tolerance = epsilon * std::max(a.cols(), a.rows()) *svd.singularValues().array().abs()(0);
     return svd.matrixV() *  (svd.singularValues().array().abs() > tolerance).select(svd.singularValues().array().inverse(), 0).matrix().asDiagonal() * svd.matrixU().adjoint();
 }


### PR DESCRIPTION
AccumCovar was not checking for a degenerate covariance matrix due to 0-value input. This fix checks for it and return identity matrix so that essentially 0/0 = 0