### PR TITLE
There was a bug in the new multi-channel FileFeeder

### DIFF
--- a/src/TimeStream.cc
+++ b/src/TimeStream.cc
@@ -180,7 +180,7 @@ unordered_map<std::string, DecoderMessage_ptr> TimeStreams::getNewCoherent(int64
                 }
                 ss << std::endl;
             }
-            GODEC_INFO << ss;
+            GODEC_INFO << ss.str();
         }
 #endif
         // Can we slice all messages at this time?

--- a/src/core_components/AudioPreProcessor.cc
+++ b/src/core_components/AudioPreProcessor.cc
@@ -160,7 +160,7 @@ void AudioPreProcessorComponent::ProcessMessage(const DecoderMessageBlock& msgBl
         sampleRate = audioMsg->mSampleRate;
         audioVecs.push_back(audioMsg->mAudio);
         vtlStretch = audioMsg->getDescriptor("vtl_stretch") == "" ? vtlStretch : boost::lexical_cast<float>(audioMsg->getDescriptor("vtl_stretch"));
-    // message is in BinaryDecoderMessage format, need to decode first
+        // message is in BinaryDecoderMessage format, need to decode first
     } else if (audioBaseMsg->getUUID() == UUID_BinaryDecoderMessage) {
         auto binaryMsg =msgBlock.get<BinaryDecoderMessage>(SlotStreamedAudio);
         auto& binaryData = binaryMsg->mData;
@@ -206,6 +206,9 @@ void AudioPreProcessorComponent::ProcessMessage(const DecoderMessageBlock& msgBl
         }
     }
 
+    // Maybe at some point this will be supported? It's not clear though what the timestamps would be if you suddenly have a new output stream that didn't exist before
+    if (numChannels != zeroMean.size()) GODEC_ERR << getLPId() << ": Number of incoming channels changed mid-stream (from " << zeroMean.size() << " to " << numChannels << "). This is currently not supported";
+
     // Resample
     std::vector<Vector> resampledAudio(numChannels);
     for (int channelIdx = 0; channelIdx < numChannels; channelIdx++) {
@@ -225,7 +228,6 @@ void AudioPreProcessorComponent::ProcessMessage(const DecoderMessageBlock& msgBl
             resampledAudio[channelIdx] = audioVecs[channelIdx];
         }
     }
-
 
     mUttReceivedResampledAudio += resampledAudio[0].size();
 

--- a/src/core_components/FileFeeder.cc
+++ b/src/core_components/FileFeeder.cc
@@ -216,10 +216,12 @@ void parseAnalistLine(std::string& analistFileLine, std::string& waveFile, std::
         if (lineEl.compare("") == 0 || lineEl.empty()) continue;
         else if (lineEl == "-c") {
             std::string channelString;
+            channels.resize(0);
             iss >> channelString;
             std::vector<std::string> channelEls;
             boost::split(channelEls, channelString, boost::is_any_of(","));
             for(int idx = 0; idx < channelEls.size(); idx++) {
+                if (channelEls[idx] == "") continue;
                 channels.push_back(boost::lexical_cast<int>(channelEls[idx]));
             }
         } else if (lineEl == "-t") {


### PR DESCRIPTION
 There was a bug in the new multi-channel FileFeeder that incorrectly set the num_channels key in the outgoing audio message. The AudioPreProcessor didnt expect that and crashed. Both the bug in FF was fixed and the AudioPreproc will throw an error now.