### PR TITLE
20191025 debug slicing option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -113,12 +113,12 @@ matrix:
       - wget -q http://archive.raspberrypi.org/debian/pool/main/a/alsa-lib/libasound2-dev_1.1.3-5+rpi3_armhf.deb
       - ar x libasound2-dev_1.1.3-5+rpi3_armhf.deb
       - tar xf data.tar.xz -C $HOME/alsa
-      - wget -q http://raspbian.mirror.constant.com/raspbian/pool/main/o/openjdk-8/openjdk-8-jdk_8u222-b10-1~deb9u1_armhf.deb
-      - ar x openjdk-8-jdk_8u222-b10-1~deb9u1_armhf.deb
+      - wget -q http://raspbian.mirror.constant.com/raspbian/pool/main/o/openjdk-8/openjdk-8-jdk_8u232-b09-1~deb9u1_armhf.deb
+      - ar x openjdk-8-jdk_8u232-b09-1~deb9u1_armhf.deb
       - mkdir $HOME/jdk
       - tar xf data.tar.xz -C $HOME/jdk
-      - wget -q http://raspbian.mirror.constant.com/raspbian/pool/main/o/openjdk-8/openjdk-8-jre-headless_8u222-b10-1~deb9u1_armhf.deb
-      - ar x openjdk-8-jre-headless_8u222-b10-1~deb9u1_armhf.deb
+      - wget -q http://raspbian.mirror.constant.com/raspbian/pool/main/o/openjdk-8/openjdk-8-jre-headless_8u232-b09-1~deb9u1_armhf.deb
+      - ar x openjdk-8-jre-headless_8u232-b09-1~deb9u1_armhf.deb
       - mkdir $HOME/jre
       - tar xf data.tar.xz -C $HOME/jre
       - mkdir $HOME/pydev

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,7 +129,7 @@ link_directories(
   )
 
 file(WRITE "${PROJECT_SOURCE_DIR}/src/include/godec/version.h" "#pragma once\n")
-if (VERSION_STRING STREQUAL "")
+if ("${VERSION_STRING}" STREQUAL "")
   # Use Git SHA as version
   execute_process(COMMAND git rev-parse --short HEAD OUTPUT_VARIABLE VERSION_STRING)
   string(REGEX REPLACE "[\ \n]+" "" VERSION_STRING "${VERSION_STRING}")

--- a/doc/Profiling.md
+++ b/doc/Profiling.md
@@ -23,6 +23,8 @@ Whether the network halts somewhere, or you get
 
 incorrect timestamps are likely at fault. Monitor the incoming messages and look at how the message streams stack up next to each other (the `should not slice past` error actually prints that stack) and try to retrace why Godec couldn't find a way to slice a contiguous block of messages out.
 
+If you want to see how a component tries to slice the incoming messages, set the optional "debug_slicing" JSON option to "true". The output will describe how the messages are being asked to slice at a certain time, and which messages prevents it.
+
 `TimeStream structure was not empty at shutdown` is a specific error message that indicates a component had received all its input data, but was not able to entirely process the received messages because they couldn't be sliced out. This can have more than one reason, one being the usual "upstream timestamps are wrong", the other that an upstream component didn't account for all stream time (which is a requirement).
 
 ### Profile

--- a/src/ChannelMessenger.cc
+++ b/src/ChannelMessenger.cc
@@ -100,7 +100,11 @@ LoopProcessor::LoopProcessor(std::string id, ComponentGraphConfig* pt) : mVerbos
     }
 
     mInputChannel.setIdVerbose(mId, mVerbose);
-    mFullStream.setIdVerbose(id, mVerbose);
+    bool debugSlicing = false;
+    if (pt->get_optional_READ_DECLARATION_BEFORE_USE<bool>("debug_slicing")) {
+        debugSlicing = pt->get<bool>("debug_slicing", "Show how the component tries to slice the messages");
+    }
+    mFullStream.setIdVerbose(id, debugSlicing);
     mPt = pt;
 }
 

--- a/src/core_components/FeatureMerger.cc
+++ b/src/core_components/FeatureMerger.cc
@@ -1,4 +1,6 @@
 #include "FeatureMerger.h"
+#include <boost/algorithm/string/join.hpp>
+#include <boost/range/adaptor/transformed.hpp>
 
 namespace Godec {
 
@@ -60,7 +62,7 @@ void FeatureMergerComponent::ProcessMessage(const DecoderMessageBlock& msgBlock)
             int64_t msgLength = audioMsg->getTime()-msgBlock.getPrevCutoff();
             std::vector<uint64_t> featTimeStamps;
             for(int sampleIdx = 0; sampleIdx < feats.cols(); sampleIdx++) {
-                uint64_t t = msgBlock.getPrevCutoff()+1+msgLength*(sampleIdx/(double)feats.cols());
+                uint64_t t = msgBlock.getPrevCutoff()+msgLength*((sampleIdx+1)/(double)feats.cols());
                 featTimeStamps.push_back(t);
             }
             featureTimestamps = featTimeStamps;


### PR DESCRIPTION
This introduces a new optional JSON option for components, "debug_slicing", which then spits out the message slicing process. This can be used for debugging slicing issues.
Also, a fix in the FeatureMerger that related to merging audio messages with non-1 ticksPerSample.