### PR TITLE
Change "Generic_ARM" to "RaspberryPi", upgrade Linaro/Eigen, add 32-bit PCM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,9 +70,9 @@ matrix:
         ./b2 clean &&\
         ./b2 -j8 -d0 cxxstd=17 cxxflags=-fPIC cflags=-fPIC --without-python link=static threading=multi threadapi=pthread define=BOOST_MATH_DISABLE_FLOAT128 &&\
         export BOOST_ROOT=$HOME/boost_1_68_0 &&\
-        wget -q http://bitbucket.org/eigen/eigen/get/3.3.4.tar.bz2 &&\
-        tar jxf 3.3.4.tar.bz2 -C $HOME &&\
-        export EIGEN_ROOT=$HOME/eigen-eigen-5a0156e40feb &&\
+        wget -q http://bitbucket.org/eigen/eigen/get/3.3.7.tar.bz2 &&\
+        tar jxf 3.3.7.tar.bz2 -C $HOME &&\
+        export EIGEN_ROOT=$HOME/eigen-eigen-323c052e1731 &&\
         export PYTHON_ROOT=/opt/rh/rh-python36/root/ &&\
         export PYTHON_HOME=/opt/rh/rh-python36/root/usr/ &&\
         export CMAKE_ARGS=\"-DBOOST_INCLUDEDIR=\$BOOST_ROOT -DBOOST_LIBRARYDIR=\$BOOST_ROOT/stage/lib/ -DEigen3_INCLUDE_DIRS=\$EIGEN_ROOT -DPYTHON_LIBRARY=\$PYTHON_ROOT/usr/lib64/libpython3.6m.so -DPYTHON_INCLUDE_DIR=\$PYTHON_ROOT/usr/include/python3.6m -DGODEC_ADDITIONAL_INCLUDE_DIRS=\$PYTHON_ROOT/usr/lib64/python3.6/site-packages/numpy/core/include/ \" &&\
@@ -92,20 +92,20 @@ matrix:
           - maven
       
       before_script:
-      - wget -q https://releases.linaro.org/components/toolchain/binaries/7.3-2018.05/armv8l-linux-gnueabihf/gcc-linaro-7.3.1-2018.05-x86_64_armv8l-linux-gnueabihf.tar.xz
-      - tar xf gcc-linaro-7.3.1-2018.05-x86_64_armv8l-linux-gnueabihf.tar.xz -C $HOME
+      - wget -q https://releases.linaro.org/components/toolchain/binaries/7.4-2019.02/armv8l-linux-gnueabihf/gcc-linaro-7.4.1-2019.02-x86_64_armv8l-linux-gnueabihf.tar.xz
+      - tar xf gcc-linaro-7.4.1-2019.02-x86_64_armv8l-linux-gnueabihf.tar.xz -C $HOME
       - wget -q https://dl.bintray.com/boostorg/release/1.68.0/source/boost_1_68_0.tar.gz
       - tar xf boost_1_68_0.tar.gz -C $HOME
       - cd $HOME/boost_1_68_0
       - ./bootstrap.sh
       - ./b2 clean
-      - "echo \"using gcc : arm : $HOME/gcc-linaro-7.3.1-2018.05-x86_64_armv8l-linux-gnueabihf/bin/armv8l-linux-gnueabihf-g++ ;\" >> project-config.jam"
+      - "echo \"using gcc : arm : $HOME/gcc-linaro-7.4.1-2019.02-x86_64_armv8l-linux-gnueabihf/bin/armv8l-linux-gnueabihf-g++ ;\" >> project-config.jam"
       - ./b2 toolset=gcc-arm -j8 -d0 cxxflags=-fPIC cflags=-fPIC --without-python link=static threading=multi threadapi=pthread define=BOOST_MATH_DISABLE_FLOAT128
       - cd $HOME
       - export BOOST_ROOT=$HOME/boost_1_68_0
-      - wget -q http://bitbucket.org/eigen/eigen/get/3.3.4.tar.bz2
-      - tar jxf 3.3.4.tar.bz2 -C $HOME
-      - export EIGEN_ROOT=$HOME/eigen-eigen-5a0156e40feb
+      - wget -q http://bitbucket.org/eigen/eigen/get/3.3.7.tar.bz2
+      - tar jxf 3.3.7.tar.bz2 -C $HOME
+      - export EIGEN_ROOT=$HOME/eigen-eigen-323c052e1731
       - mkdir $HOME/alsa
       - wget -q http://archive.raspberrypi.org/debian/pool/main/a/alsa-lib/libasound2_1.1.3-5+rpt4_armhf.deb
       - ar x libasound2_1.1.3-5+rpt4_armhf.deb
@@ -145,8 +145,9 @@ matrix:
 
       env: PYTHON_HOME=$HOME/pydev/usr
            PATH=/usr/lib/jvm/java-8-openjdk-amd64/jre/bin:$PATH
-           CXX=$HOME/gcc-linaro-7.3.1-2018.05-x86_64_armv8l-linux-gnueabihf/bin/armv8l-linux-gnueabihf-g++ 
-           PLATFORM=Generic_ARM
+           CXX=$HOME/gcc-linaro-7.4.1-2019.02-x86_64_armv8l-linux-gnueabihf/bin/armv8l-linux-gnueabihf-g++
+           PLATFORM=RaspberryPi
+           RASPBERRY_PI_OPT_FLAGS="-mcpu=cortex-a53 -rdynamic -mfpu=neon-fp-armv8 -mneon-for-64bits"
            OS_STRING=RaspberryPi3
 
     - language: android
@@ -170,9 +171,9 @@ matrix:
       - mkdir "$HOME/boost" || true		
       - unzip -q boost-android-r18b-armeabi-v7a-1.68.0.zip -d $HOME/boost
       - export BOOST_ROOT=$HOME/boost
-      - wget -q http://bitbucket.org/eigen/eigen/get/3.3.4.tar.bz2
-      - tar jxf 3.3.4.tar.bz2 -C $HOME
-      - export EIGEN_ROOT=$HOME/eigen-eigen-5a0156e40feb
+      - wget -q http://bitbucket.org/eigen/eigen/get/3.3.7.tar.bz2
+      - tar jxf 3.3.7.tar.bz2 -C $HOME
+      - export EIGEN_ROOT=$HOME/eigen-eigen-323c052e1731
       - export CMAKE_ARGS="-DBoost_NO_SYSTEM_PATHS=ON -DBOOST_INCLUDEDIR=$BOOST_ROOT/include/ -DBOOST_LIBRARYDIR=$BOOST_ROOT/lib/armeabi-v7a -DEigen3_INCLUDE_DIRS=$EIGEN_ROOT"
       - echo no | android create avd --force --name test --target android-22 --abi armeabi-v7a
       - emulator -avd test -no-skin -no-audio -no-window -gpu off -no-boot-anim &
@@ -202,9 +203,9 @@ matrix:
       - curl -O -J -L https://sourceforge.net/projects/boost/files/boost-binaries/1.68.0/boost_1_68_0-bin-msvc-all-32-64.7z/download
       - 7z x boost_1_68_0-bin-msvc-all-32-64.7z boost_1_68_0/lib64-msvc-14.1/* boost_1_68_0/boost/* 
       - rm -f boost_1_68_0-bin-msvc-all-32-64.7z
-      - wget -q http://bitbucket.org/eigen/eigen/get/3.3.4.tar.bz2
-      - tar jxf 3.3.4.tar.bz2 -C $HOME
-      - export EIGEN_ROOT=$HOME/eigen-eigen-5a0156e40feb
+      - wget -q http://bitbucket.org/eigen/eigen/get/3.3.7.tar.bz2
+      - tar jxf 3.3.7.tar.bz2 -C $HOME
+      - export EIGEN_ROOT=$HOME/eigen-eigen-323c052e1731
       - choco install python
       - choco install numpy
       - wget -q https://download.java.net/java/GA/jdk12.0.2/e482c34c86bd4bf8b56c0b35558996b9/10/GPL/openjdk-12.0.2_windows-x64_bin.zip
@@ -221,7 +222,7 @@ matrix:
 script:
       - cd $TRAVIS_BUILD_DIR
       - mkdir cmake-build && cd cmake-build 
-      - "\"$MY_CMAKE\" -DPLATFORM=$PLATFORM -DVERSION_STRING=\"$TRAVIS_TAG\" $CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=../install ../"
+      - "\"$MY_CMAKE\" -DPLATFORM=$PLATFORM -DRASPBERRY_PI_OPT_FLAGS=\"$RASPBERRY_PI_OPT_FLAGS\" -DVERSION_STRING=\"$TRAVIS_TAG\" $CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=../install ../"
       - eval "$MY_MAKE_COMMAND"
       - cd ../install
       - tar cvzf $HOME/godec.$OS_STRING.tgz *

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.7)
 
-if (NOT (PLATFORM STREQUAL "Linux" OR PLATFORM STREQUAL "Android" OR PLATFORM STREQUAL "Generic_ARM" OR PLATFORM STREQUAL "Windows"))
-  message(FATAL_ERROR "Please specify the PLATFORM variable <Linux, Android, Generic_ARM, Windows")
+if (NOT (PLATFORM STREQUAL "Linux" OR PLATFORM STREQUAL "Android" OR PLATFORM STREQUAL "RaspberryPi" OR PLATFORM STREQUAL "Windows"))
+  message(FATAL_ERROR "Please specify the PLATFORM variable <Linux, Android, RaspberryPi, Windows")
 endif()
 
 if (PLATFORM STREQUAL "Windows")
@@ -33,11 +33,11 @@ if (NOT PLATFORM STREQUAL "Windows")
   add_compile_options(-Wall -Wno-sign-compare -Wno-unused-local-typedefs -Winit-self )
 endif()
 
-if ((PLATFORM STREQUAL "Linux") OR (PLATFORM STREQUAL "Generic_ARM"))
+if ((PLATFORM STREQUAL "Linux") OR (PLATFORM STREQUAL "RaspberryPi"))
   add_compile_options(-pthread)
 endif()
 set(CMAKE_CXX_FLAGS_DEBUG "-g -DDEBUG")
-set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG")
+set(CMAKE_CXX_FLAGS_RELEASE "-Ofast -DNDEBUG")
 
 find_program(CCACHE_PROGRAM ccache)
 if(DEFINED ENV{CCACHE_DIR} AND CCACHE_PROGRAM)
@@ -85,10 +85,13 @@ if (NOT PLATFORM STREQUAL "Android")
 endif()
 
 if (PLATFORM STREQUAL "Android")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Ofast -DANDROID -marm -march=armv7-a -mfpu=neon -Wno-narrowing -fexceptions -frtti -Wno-deprecated-register -Wno-redeclared-class-member")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DANDROID -marm -march=armv7-a -mfpu=neon -Wno-narrowing -fexceptions -frtti -Wno-deprecated-register -Wno-redeclared-class-member")
   list(APPEND LINKER_LIBS -lOpenSLES)
-elseif(PLATFORM STREQUAL "Generic_ARM")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Ofast -mcpu=cortex-a53 -rdynamic -mfpu=neon-fp-armv8 -mneon-for-64bits -mhard-float")
+elseif(PLATFORM STREQUAL "RaspberryPi")
+  if (NOT DEFINED RASPBERRY_PI_OPT_FLAGS)
+    message(FATAL_ERROR "For RaspberryPi platform, need to specify RASPBERRY_PI_OPT_FLAGS")
+  endif()
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${RASPBERRY_PI_OPT_FLAGS} -mhard-float")
 elseif(PLATFORM STREQUAL "Linux")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-ignored-attributes -Wno-int-in-bool-context -msse -msse2")
 elseif(PLATFORM STREQUAL "Windows")
@@ -98,7 +101,7 @@ endif()
 add_definitions(
   -DEIGEN_NO_DEBUG
   -DNDEBUG
-  -O2 
+  -Ofast
 )
 if (NOT PLATFORM STREQUAL "Windows")
   add_definitions(
@@ -141,6 +144,8 @@ execute_process(COMMAND bash "-c" "grep EIGEN_WORLD_VERSION ${Eigen3_INCLUDE_DIR
 file(APPEND "${PROJECT_SOURCE_DIR}/src/include/godec/version.h" "#define GODEC_EIGEN_WORLD_VERSION ${EIGEN_WORLD_VERSION}\n")
 execute_process(COMMAND bash "-c" "grep EIGEN_MAJOR_VERSION ${Eigen3_INCLUDE_DIRS}/Eigen/src/Core/util/Macros.h | head -1 | awk '{print $3;}'" OUTPUT_VARIABLE EIGEN_MAJOR_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
 file(APPEND "${PROJECT_SOURCE_DIR}/src/include/godec/version.h" "#define GODEC_EIGEN_MAJOR_VERSION ${EIGEN_MAJOR_VERSION}\n")
+execute_process(COMMAND bash "-c" "grep EIGEN_MINOR_VERSION ${Eigen3_INCLUDE_DIRS}/Eigen/src/Core/util/Macros.h | head -1 | awk '{print $3;}'" OUTPUT_VARIABLE EIGEN_MINOR_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
+file(APPEND "${PROJECT_SOURCE_DIR}/src/include/godec/version.h" "#define GODEC_EIGEN_MINOR_VERSION ${EIGEN_MINOR_VERSION}\n")
 
 set(SOURCE_FILES
   src/include/godec/channel.h

--- a/doc/CoreComponents.md
+++ b/doc/CoreComponents.md
@@ -478,7 +478,7 @@ The "start_on_boot" parameter, when set to "false", will require the "control" s
 #### Parameters
 | Parameter | Type | Description |
 | --- | --- | --- |
-| chunk\_size | int | Chunk size in samples |
+| chunk\_size | int | Chunk size in samples (set to -1 for minimum latency configuratio) |
 | num\_channels | int | Number of channels (1=mono, 2=stereo) |
 | sample\_depth | int | Sample depth (8,16,24 etc bit) |
 | sampling\_rate | float | Sampling rate |

--- a/src/core_components/AudioPreProcessor.cc
+++ b/src/core_components/AudioPreProcessor.cc
@@ -181,7 +181,9 @@ void AudioPreProcessorComponent::ProcessMessage(const DecoderMessageBlock& msgBl
                     if (bytesPerSample == 1) {
                         audioVecs[channelIdx](sampleIdx) = *samplePtr;
                     } else if (bytesPerSample == 2) {
-                        audioVecs[channelIdx](sampleIdx) = *((short*)samplePtr);
+                        audioVecs[channelIdx](sampleIdx) = *((int16_t*)samplePtr);
+                    } else if (bytesPerSample == 4) {
+                        audioVecs[channelIdx](sampleIdx) = *((int32_t*)samplePtr);
                     }
                 } else if (parser.baseFormat == MuLaw) {
                     audioVecs[channelIdx](sampleIdx) = Mulaw_Decode(*samplePtr);

--- a/src/core_components/CMakeLists.txt
+++ b/src/core_components/CMakeLists.txt
@@ -58,7 +58,7 @@ else()
   set(GODEC_CORE_NAME "godec_core")
 endif()
 
-if ((PLATFORM STREQUAL "Linux") OR (PLATFORM STREQUAL "Generic_ARM"))
+if ((PLATFORM STREQUAL "Linux") OR (PLATFORM STREQUAL "RaspberryPi"))
   set(PLATFORM_SPECIFIC_LIBS ${JAVA_JVM_LIBRARY} -ldl -lrt)
   set(LINKER_GODEC_ARGS -Wl,--whole-archive godec_core_static -Wl,--no-whole-archive)
 elseif (PLATFORM STREQUAL "Android")

--- a/src/include/godec/HelperFuncs.h
+++ b/src/include/godec/HelperFuncs.h
@@ -30,8 +30,8 @@ using std::unordered_set;
 #ifndef _MSC_VER
 #define STRING2(x) #x
 #define STRING(x) STRING2(x)
-#if ((EIGEN_WORLD_VERSION != GODEC_EIGEN_WORLD_VERSION) || (EIGEN_MAJOR_VERSION != GODEC_EIGEN_MAJOR_VERSION))
-#pragma message "This version of Godec was compiled with Eigen library version " STRING(GODEC_EIGEN_MAJOR_VERSION) "." STRING(GODEC_EIGEN_MAJOR_VERSION) ", but your Eigen version is " STRING(EIGEN_WORLD_VERSION) "." STRING(EIGEN_MAJOR_VERSION) ". This version mismatch can cause stack corruptions"
+#if ((EIGEN_WORLD_VERSION != GODEC_EIGEN_WORLD_VERSION) || (EIGEN_MAJOR_VERSION != GODEC_EIGEN_MAJOR_VERSION) || (EIGEN_MINOR_VERSION != GODEC_EIGEN_MINOR_VERSION))
+#pragma message "This version of Godec was compiled with Eigen library version " STRING(GODEC_EIGEN_MAJOR_VERSION) "." STRING(GODEC_EIGEN_MAJOR_VERSION) "." STRING(GODEC_EIGEN_MINOR_VERSION) ", but your Eigen version is " STRING(EIGEN_WORLD_VERSION) "." STRING(EIGEN_MAJOR_VERSION) "." STRING(EIGEN_MINOR_VERSION) ". This version mismatch can cause stack corruptions"
 #error
 #endif
 #endif

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -2,7 +2,7 @@
 set -e
 
 if [ "$#" -ne 2 ]; then
-    echo "Usage: run_tests.sh <installation directory> <platform string, e.g. Linux, Android, Generic_ARM, Windows>"
+    echo "Usage: run_tests.sh <installation directory> <platform string, e.g. Linux, Android, RaspberryPi, Windows>"
     exit -1
 fi
 
@@ -18,7 +18,7 @@ then
   only_test="android.test"
 fi
 
-if [ "$2" == "Generic_ARM" ] 
+if [ "$2" == "RaspberryPi" ] 
 then
   skipped_tests=""
   only_test="dummy.test"


### PR DESCRIPTION
- Change "Generic_ARM" to "RaspberryPi" and require Pi 3/4 specific optimization options to be specified from the outside
- Use latest linaro (7.4.1) and Eigen (3.3.7). Enforce stricter check on Eigen version
- Added support for 32-bit PCM in AudioPreprocessor