### PR TITLE
mCurrentRouteIdx could be uninitialized

### DIFF
--- a/src/core_components/Router.cc
+++ b/src/core_components/Router.cc
@@ -36,8 +36,8 @@ RouterComponent::RouterComponent(std::string id, ComponentGraphConfig* configPt)
     } else if (router_type_string == "utterance_round_robin") {
         mMode = Mode::UtteranceRoundRobin;
         mNumRoutes = configPt->get<int>("num_outputs", "Number of outputs to distribute to");
-        mCurrentRouteIdx = 0;
     } else GODEC_ERR << "Unknown router_type '" << router_type_string << "'" << std::endl;
+    mCurrentRouteIdx = 0;
 
     addInputSlotAndUUID(SlotRoutingStream, UUID_AnyDecoderMessage);
     addInputSlotAndUUID(SlotToRouteStream, UUID_AnyDecoderMessage);


### PR DESCRIPTION
mCurrentRouteIdx could be uninitialized. In the case that uninitialized value was negative, the modulo ended up being negative.