### PR TITLE
Return to stringent AudioDecoderMessage check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,33 +54,7 @@ matrix:
       - sudo docker pull ${OS_TYPE}:${OS_TYPE}${OS_VERSION}
   
       script:
-      - | 
-        sudo docker run --rm=true -v $HOME:$HOME:rw ${OS_TYPE}:${OS_TYPE}${OS_VERSION} /bin/bash -v -c "\
-        cd $HOME &&\
-        yum -y groupinstall 'Development Tools' &&\
-        yum -y install centos-release-scl &&\
-        yum -y install devtoolset-7-gcc\* &&\
-        yum -y install libtool wget alsa-lib alsa-lib-devel rh-python36-python rh-python36-python-devel rh-python36-numpy java-1.8.0-openjdk java-1.8.0-openjdk-devel zlib-devel maven which &&\
-        export JAVA_HOME=\$(realpath \$(dirname \$(which java))/..) &&\
-        source /opt/rh/devtoolset-7/enable &&\
-        wget -q https://dl.bintray.com/boostorg/release/1.68.0/source/boost_1_68_0.tar.gz &&\
-        tar xf boost_1_68_0.tar.gz -C \"$HOME\" &&\
-        cd $HOME/boost_1_68_0 &&\
-        ./bootstrap.sh &&\
-        ./b2 clean &&\
-        ./b2 -j8 -d0 cxxstd=17 cxxflags=-fPIC cflags=-fPIC --without-python link=static threading=multi threadapi=pthread define=BOOST_MATH_DISABLE_FLOAT128 &&\
-        export BOOST_ROOT=$HOME/boost_1_68_0 &&\
-        wget -q http://bitbucket.org/eigen/eigen/get/3.3.7.tar.bz2 &&\
-        tar jxf 3.3.7.tar.bz2 -C $HOME &&\
-        export EIGEN_ROOT=$HOME/eigen-eigen-323c052e1731 &&\
-        export PYTHON_ROOT=/opt/rh/rh-python36/root/ &&\
-        export PYTHON_HOME=/opt/rh/rh-python36/root/usr/ &&\
-        export CMAKE_ARGS=\"-DBOOST_INCLUDEDIR=\$BOOST_ROOT -DBOOST_LIBRARYDIR=\$BOOST_ROOT/stage/lib/ -DEigen3_INCLUDE_DIRS=\$EIGEN_ROOT -DPYTHON_LIBRARY=\$PYTHON_ROOT/usr/lib64/libpython3.6m.so -DPYTHON_INCLUDE_DIR=\$PYTHON_ROOT/usr/include/python3.6m -DGODEC_ADDITIONAL_INCLUDE_DIRS=\$PYTHON_ROOT/usr/lib64/python3.6/site-packages/numpy/core/include/ \" &&\
-        cd $TRAVIS_BUILD_DIR && mkdir cmake-build && cd cmake-build &&\
-        \"$MY_CMAKE\" -DPLATFORM=$PLATFORM -DVERSION_STRING=\"$TRAVIS_TAG\" \$CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=../install ../ &&\
-        eval \"$MY_MAKE_COMMAND\" &&\
-        cd ../install &&\
-        tar cvzf $HOME/godec.$OS_STRING.tgz *" 
+      - sudo docker run --rm=true -v $HOME:$HOME:rw ${OS_TYPE}:${OS_TYPE}${OS_VERSION} /bin/bash -v -c " export MY_CMAKE=\"$MY_CMAKE\" && export MY_MAKE_COMMAND=\"$MY_MAKE_COMMAND\" && export TRAVIS_BUILD_DIR=\"$TRAVIS_BUILD_DIR\" && cd $TRAVIS_BUILD_DIR && export PLATFORM=\"$PLATFORM\" && ./centos7_build.sh " 
 
     - language: cpp
       os: linux

--- a/centos7_build.sh
+++ b/centos7_build.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -e
+cd $HOME 
+yum -y groupinstall 'Development Tools' 
+yum -y install centos-release-scl 
+yum -y install devtoolset-7-gcc\* 
+yum -y install libtool wget alsa-lib alsa-lib-devel rh-python36-python rh-python36-python-devel rh-python36-numpy java-1.8.0-openjdk java-1.8.0-openjdk-devel zlib-devel maven which 
+export JAVA_HOME=$(realpath $(dirname $(which java))/..) 
+source /opt/rh/devtoolset-7/enable 
+wget -q https://dl.bintray.com/boostorg/release/1.68.0/source/boost_1_68_0.tar.gz 
+tar xf boost_1_68_0.tar.gz -C "$HOME" 
+cd $HOME/boost_1_68_0 
+./bootstrap.sh 
+./b2 clean 
+./b2 -j8 -d0 cxxstd=17 cxxflags=-fPIC cflags=-fPIC --without-python link=static threading=multi threadapi=pthread define=BOOST_MATH_DISABLE_FLOAT128 
+export BOOST_ROOT=$HOME/boost_1_68_0 
+wget -q http://bitbucket.org/eigen/eigen/get/3.3.7.tar.bz2 
+tar jxf 3.3.7.tar.bz2 -C $HOME 
+export EIGEN_ROOT=$HOME/eigen-eigen-323c052e1731 
+export PYTHON_ROOT=/opt/rh/rh-python36/root/ 
+export PYTHON_HOME=/opt/rh/rh-python36/root/usr/ 
+export CMAKE_ARGS="-DBOOST_INCLUDEDIR=$BOOST_ROOT -DBOOST_LIBRARYDIR=$BOOST_ROOT/stage/lib/ -DEigen3_INCLUDE_DIRS=$EIGEN_ROOT -DPYTHON_LIBRARY=$PYTHON_ROOT/usr/lib64/libpython3.6m.so -DPYTHON_INCLUDE_DIR=$PYTHON_ROOT/usr/include/python3.6m -DGODEC_ADDITIONAL_INCLUDE_DIRS=$PYTHON_ROOT/usr/lib64/python3.6/site-packages/numpy/core/include/ " 
+cd $TRAVIS_BUILD_DIR && rm -rf cmake-build && mkdir cmake-build && cd cmake-build 
+"$MY_CMAKE" -DPLATFORM=$PLATFORM -DVERSION_STRING="$TRAVIS_TAG" $CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=../install ../ 
+eval "$MY_MAKE_COMMAND" 
+cd ../install 
+tar cvzf $HOME/godec.$OS_STRING.tgz *

--- a/src/core_components/GodecMessages.cc
+++ b/src/core_components/GodecMessages.cc
@@ -81,9 +81,9 @@ bool AudioDecoderMessage::mergeWith(DecoderMessage_ptr msg, DecoderMessage_ptr &
 }
 
 bool AudioDecoderMessage::canSliceAt(uint64_t sliceTime, std::vector<DecoderMessage_ptr>& msgList, uint64_t streamStartOffset, bool verbose) {
-    // Initially this actually contained a very stringent check that the length between getTime() and sliceTime are multple of mTicksPerSample.
-    // This totally doesn't work however for fractional mTicksPerSample (e.g. after resampling from 48kHz to 44.1kHz) where now the ticks are little more than rounded approximations of the sub-fraction ticks. So, we are dropping the check and are returning to allowing any slicing that is asked for, Shannong theorem be damned.
-    return true;
+    // We are returning to the stringent check even though fractional ticksPerSample due to downsamplig can cause problems when trying to slice out streams that came from different ticksPerSample (e.g. slicing out features computed from 44.1kHz and 10kHz). The solution has to rather be to create a custom component that "resamples" the features so they align the timestamps with each other
+    bool canSlice = (((int64_t)getTime()-(int64_t)sliceTime) % (int64_t)round(mTicksPerSample) == 0);
+    return canSlice;
 }
 
 bool AudioDecoderMessage::sliceOut(uint64_t sliceTime, DecoderMessage_ptr& sliceMsg, std::vector<DecoderMessage_ptr>& msgList, int64_t streamStartOffset, bool verbose) {


### PR DESCRIPTION
This change returns the AudioDecoderMessage's canSliceAt function to the original stringent check to be multiple of ticksPerSample. The check was dropped because mixing features and audio that originate from different ticksPerSample (e.g. due to resampling in the middle) caused them to land on different ticks and thus made the unsliceable. The solution, if this actually is necessary for those projects, has to be a custom component that realigns one stream to the other.

It also moves the docker commands for Centos7 into a convenient script.