### PR TITLE
New message

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,12 +87,12 @@ matrix:
       - wget -q http://archive.raspberrypi.org/debian/pool/main/a/alsa-lib/libasound2-dev_1.1.3-5+rpi3_armhf.deb
       - ar x libasound2-dev_1.1.3-5+rpi3_armhf.deb
       - tar xf data.tar.xz -C $HOME/alsa
-      - wget -q http://raspbian.mirror.constant.com/raspbian/pool/main/o/openjdk-8/openjdk-8-jdk_8u242-b08-1~deb9u1_armhf.deb
-      - ar x openjdk-8-jdk_8u242-b08-1~deb9u1_armhf.deb
+      - wget -q http://raspbian.mirror.constant.com/raspbian/pool/main/o/openjdk-8/openjdk-8-jdk_8u252-b09-1~deb9u1_armhf.deb 
+      - ar x openjdk-8-jdk_8u252-b09-1~deb9u1_armhf.deb
       - mkdir $HOME/jdk
       - tar xf data.tar.xz -C $HOME/jdk
-      - wget -q http://raspbian.mirror.constant.com/raspbian/pool/main/o/openjdk-8/openjdk-8-jre-headless_8u242-b08-1~deb9u1_armhf.deb
-      - ar x openjdk-8-jre-headless_8u242-b08-1~deb9u1_armhf.deb
+      - wget -q http://raspbian.mirror.constant.com/raspbian/pool/main/o/openjdk-8/openjdk-8-jre-headless_8u252-b09-1~deb9u1_armhf.deb
+      - ar x openjdk-8-jre-headless_8u252-b09-1~deb9u1_armhf.deb
       - mkdir $HOME/jre
       - tar xf data.tar.xz -C $HOME/jre
       - mkdir $HOME/pydev

--- a/src/ChannelMessenger.cc
+++ b/src/ChannelMessenger.cc
@@ -39,6 +39,7 @@ std::string LoopProcessor::QuietGodec = "quiet_godec";
 std::string LoopProcessor::SlotTimeMap = "time_map";
 std::string LoopProcessor::SlotControl = "control";
 std::string LoopProcessor::SlotSearchOutput = "fst_search_output";
+std::string LoopProcessor::SlotAudioInfo = "audio_info";
 
 std::string DecoderMessage::describeThyself() const {
     std::stringstream ss;

--- a/src/core_components/AudioPreProcessor.cc
+++ b/src/core_components/AudioPreProcessor.cc
@@ -139,6 +139,7 @@ AudioPreProcessorComponent::AudioPreProcessorComponent(std::string id, Component
         ss << SlotStreamedAudio << "_" << channelIdx;
         requiredOutputSlots.push_back(ss.str());
     }
+    requiredOutputSlots.push_back(SlotAudioInfo);
     initOutputs(requiredOutputSlots);
 }
 
@@ -296,6 +297,10 @@ void AudioPreProcessorComponent::ProcessMessage(const DecoderMessageBlock& msgBl
         (boost::const_pointer_cast<DecoderMessage>(outMsg))->setFullDescriptorString(audioBaseMsg->getFullDescriptorString());
         pushToOutputs(ss.str(), outMsg);
     }
+
+    DecoderMessage_ptr audioInfoMsg = AudioInfoDecoderMessage::create(outTimestamp, mTargetSamplingRate, outputTimePerSample);
+    (boost::const_pointer_cast<DecoderMessage>(audioInfoMsg))->setFullDescriptorString(audioBaseMsg->getFullDescriptorString());
+    pushToOutputs(SlotAudioInfo, audioInfoMsg);
 
     // End of utterance? Reset everything
     if (convStateMsg->mLastChunkInUtt) {

--- a/src/core_components/GodecMessages.h
+++ b/src/core_components/GodecMessages.h
@@ -28,6 +28,7 @@ extern uuid UUID_NbestDecoderMessage;
 extern uuid UUID_TimeMapDecoderMessage;
 extern uuid UUID_BinaryDecoderMessage;
 extern uuid UUID_JsonDecoderMessage;
+extern uuid UUID_AudioInfoDecoderMessage;
 
 enum ProcessingMode {
     LowLatency,
@@ -76,6 +77,39 @@ class AudioDecoderMessage : public DecoderMessage {
         ar & boost::serialization::base_object<DecoderMessage>(*this);
         ar & mSampleRate;
         ar & mAudio;
+        ar & mTicksPerSample;
+    }
+};
+
+class AudioInfoDecoderMessage : public DecoderMessage {
+  public:
+    float mSampleRate;
+    float mTicksPerSample;
+
+    std::string describeThyself() const;
+    DecoderMessage_ptr clone() const;
+
+    static DecoderMessage_ptr create(uint64_t time, float sampleRate, float ticksPerSample);
+    bool mergeWith(DecoderMessage_ptr msg, DecoderMessage_ptr &remainingMsg, bool verbose);
+    bool canSliceAt(uint64_t sliceTime, std::vector<DecoderMessage_ptr>& msgList, uint64_t streamStartOffset, bool verbose);
+    bool sliceOut(uint64_t sliceTime, DecoderMessage_ptr& sliceMsg, std::vector<DecoderMessage_ptr>& msgList, int64_t streamStartOffset, bool verbose);
+    void shiftInTime(int64_t deltaT);
+    jobject toJNI(JNIEnv* env);
+    static DecoderMessage_ptr fromJNI(JNIEnv* env, jobject jMsg);
+#ifndef ANDROID
+    PyObject* toPython();
+    static DecoderMessage_ptr fromPython(PyObject* pMsg);
+#endif
+
+    uuid getUUID() const  { return UUID_AudioInfoDecoderMessage; }
+    static uuid getUUIDStatic() { return UUID_AudioInfoDecoderMessage; }
+
+  private:
+    friend class boost::serialization::access;
+    template<typename Archive>
+    void serialize(Archive & ar, const unsigned int version) {
+        ar & boost::serialization::base_object<DecoderMessage>(*this);
+        ar & mSampleRate;
         ar & mTicksPerSample;
     }
 };

--- a/src/include/godec/ChannelMessenger.h
+++ b/src/include/godec/ChannelMessenger.h
@@ -224,6 +224,7 @@ class LoopProcessor {
     static std::string SlotTimeMap;
     static std::string SlotControl;
     static std::string SlotSearchOutput;
+    static std::string SlotAudioInfo;
 
     // Don't use the following
     void startDecodingLoop();

--- a/test/resample_sub.json
+++ b/test/resample_sub.json
@@ -14,7 +14,8 @@
     },
     "outputs":
     {
-      "streamed_audio_0": "preproc_audio"
+      "streamed_audio_0": "preproc_audio",
+      "audio_info": "streamed_info"
     }
   },
   "dummy_comp":


### PR DESCRIPTION
AudioPreProcessor now outputs a new message type audio_info. This message is always slice-able and carries the sampleRate and the ticksPerSample. This is useful in downstream components. Temporary fix until the router is rewritten.