### PR TITLE
Add fix to recursively bring up component libraries to the top level …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 before_install:
-        - wget -q http://www.cmake.org/files/v3.14/cmake-3.14.5-Linux-x86_64.tar.gz && tar xzf cmake-3.14.5-Linux-x86_64.tar.gz -C $HOME
-        - export MY_CMAKE=$HOME/cmake-3.14.5-Linux-x86_64/bin/cmake
+        - export MY_CMAKE=cmake
         - export MY_MAKE_COMMAND="make -j4 install VERBOSE=1 && make test ARGS=\"-V\""
 
 matrix:
@@ -26,7 +25,7 @@ matrix:
            PLATFORM=Linux
            OS_STRING=Linux
       before_script:
-      - wget -q https://dl.bintray.com/boostorg/release/1.68.0/source/boost_1_68_0.tar.gz
+      - wget -q https://boostorg.jfrog.io/artifactory/main/release/1.68.0/source/boost_1_68_0.tar.gz
       - tar xf boost_1_68_0.tar.gz -C $HOME
       - cd $HOME/boost_1_68_0
       - ./bootstrap.sh
@@ -68,7 +67,7 @@ matrix:
       before_script:
       - wget -q https://releases.linaro.org/components/toolchain/binaries/7.4-2019.02/armv8l-linux-gnueabihf/gcc-linaro-7.4.1-2019.02-x86_64_armv8l-linux-gnueabihf.tar.xz
       - tar xf gcc-linaro-7.4.1-2019.02-x86_64_armv8l-linux-gnueabihf.tar.xz -C $HOME
-      - wget -q https://dl.bintray.com/boostorg/release/1.68.0/source/boost_1_68_0.tar.gz
+      - wget -q https://boostorg.jfrog.io/artifactory/main/release/1.68.0/source/boost_1_68_0.tar.gz
       - tar xf boost_1_68_0.tar.gz -C $HOME
       - cd $HOME/boost_1_68_0
       - ./bootstrap.sh

--- a/src/ComponentGraph.cc
+++ b/src/ComponentGraph.cc
@@ -86,6 +86,19 @@ ComponentGraph::ComponentGraph(std::string prefix, std::string inFile, Component
         subConfig->AddSubtree(overrideTree->GetSubtree(v.key(), true)->GetPtree());
         lp = LoadComponent(componentType, componentName, subConfig);
 
+        //Adds all the libraries recursively to the top level ComponentGraph.
+        //This is needed if one wants to push a custom Message from
+        //a library not specified in the top level JSON from JAVA or PYTHON.
+        if (componentType == "SubModule") {
+            auto subModuleComponent = (Submodule*)lp;
+            for (auto dllNameIt = subModuleComponent->mCgraph->mGlobalDllName2Handle->begin();
+                    dllNameIt != subModuleComponent->mCgraph->mGlobalDllName2Handle->end(); dllNameIt++) {
+                std::string dllName = dllNameIt->first;
+            }
+            mGlobalDllName2Handle->insert(subModuleComponent->mCgraph->mGlobalDllName2Handle->begin(),
+                    subModuleComponent->mCgraph->mGlobalDllName2Handle->end());
+        }
+
         subConfig->ParameterCheck();
         mComponents[componentName] = boost::shared_ptr<LoopProcessor>(lp);
     }


### PR DESCRIPTION
Recursively adds SubModule Godec component libraries to the toplevel component graph. Needed to push in Godec messages defined in component libraries from the JAVA or PYTHON API.